### PR TITLE
refactor: use "new" default stage names

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -6,4 +6,5 @@
   entry: perlcritic
   args: [--quiet]
   types: [perl]
-  stages: [commit, merge-commit, push, manual]
+  stages: [pre-commit, pre-merge-commit, pre-push, manual]
+  minimum_pre_commit_version: 3.2.0 # for "stages" names


### PR DESCRIPTION
To avoid a deprecation warning with pre-commit 4.

The "new" names are available in >= 3.2.0.