### PR TITLE
ci: remove unnecessary actions/setup-python

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
       # No caching as we're expected to run rarely
       - name: Install dependencies and run checks
         run: |


### PR DESCRIPTION
We're fine with the one in the image, and weren't specifying a version to install, so that's what we had even with setup-python. Along with a warning that we didn't specify a version.